### PR TITLE
fix(device_management_service): rename enable_mdm_disown to allow_release and fix post-create inconsistency

### DIFF
--- a/docs/resources/device_management_service.md
+++ b/docs/resources/device_management_service.md
@@ -21,7 +21,7 @@ resource "axm_device_management_service" "example" {
     data = filebase64("${path.module}/PublicKey.pem")
   }
 
-  enable_mdm_disown = false
+  allow_release = false
 
   device_ids = [
     "FAKE000ABC123",
@@ -40,8 +40,8 @@ resource "axm_device_management_service" "example" {
 
 ### Optional
 
+- `allow_release` (Boolean) Allow this service to release devices.
 - `device_ids` (Set of String) Set of device serial numbers to assign to this MDM server.
-- `enable_mdm_disown` (Boolean) When true, devices can be released from MDM without being removed from Apple Business Manager.
 - `server_certificate` (Attributes) X.509 MDM certificate. Required when creating a new server. Not returned by the API; stored in state as provided. (see [below for nested schema](#nestedatt--server_certificate))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/examples/resources/axm_device_management_service/resource.tf
+++ b/examples/resources/axm_device_management_service/resource.tf
@@ -6,7 +6,7 @@ resource "axm_device_management_service" "example" {
     data = filebase64("${path.module}/PublicKey.pem")
   }
 
-  enable_mdm_disown = false
+  allow_release = false
 
   device_ids = [
     "FAKE000ABC123",

--- a/internal/resources/device_management_service/crud.go
+++ b/internal/resources/device_management_service/crud.go
@@ -53,7 +53,7 @@ func (r *DeviceManagementServiceResource) Create(ctx context.Context, req resour
 		return
 	}
 
-	enableDisown := data.EnableMdmDisown.ValueBoolPointer()
+	enableDisown := data.AllowRelease.ValueBoolPointer()
 	attrs := client.MdmServerCreateAttributes{
 		ServerName: data.Name.ValueString(),
 		ServerCertificate: client.MdmServerCertificate{
@@ -73,7 +73,8 @@ func (r *DeviceManagementServiceResource) Create(ctx context.Context, req resour
 
 	data.ID = types.StringValue(srv.ID)
 	data.Type = types.StringValue(srv.Attributes.ServerType)
-	data.EnableMdmDisown = types.BoolValue(srv.Attributes.EnableMdmDisownFlag)
+	// AllowRelease is not reliably echoed by the create response; keep the plan value.
+	// Read will reconcile on the next refresh if Apple silently ignored it.
 
 	deviceIDs := extractStrings(data.DeviceIDs)
 	if len(deviceIDs) > 0 {
@@ -170,7 +171,7 @@ func (r *DeviceManagementServiceResource) Read(ctx context.Context, req resource
 
 	data.Name = types.StringValue(srv.Attributes.ServerName)
 	data.Type = types.StringValue(srv.Attributes.ServerType)
-	data.EnableMdmDisown = types.BoolValue(srv.Attributes.EnableMdmDisownFlag)
+	data.AllowRelease = types.BoolValue(srv.Attributes.EnableMdmDisownFlag)
 
 	deviceIDs, err := r.client.GetDeviceManagementServiceSerialNumbers(readCtx, data.ID.ValueString())
 	if err != nil {
@@ -230,8 +231,8 @@ func (r *DeviceManagementServiceResource) Update(ctx context.Context, req resour
 			serverAttrs.ServerName = &v
 			changed = true
 		}
-		if !plan.EnableMdmDisown.Equal(state.EnableMdmDisown) {
-			v := plan.EnableMdmDisown.ValueBool()
+		if !plan.AllowRelease.Equal(state.AllowRelease) {
+			v := plan.AllowRelease.ValueBool()
 			serverAttrs.EnableMdmDisownFlag = &v
 			changed = true
 		}
@@ -258,7 +259,7 @@ func (r *DeviceManagementServiceResource) Update(ctx context.Context, req resour
 				return
 			}
 			plan.Type = types.StringValue(srv.Attributes.ServerType)
-			plan.EnableMdmDisown = types.BoolValue(srv.Attributes.EnableMdmDisownFlag)
+			plan.AllowRelease = types.BoolValue(srv.Attributes.EnableMdmDisownFlag)
 		}
 	}
 

--- a/internal/resources/device_management_service/model_types.go
+++ b/internal/resources/device_management_service/model_types.go
@@ -26,7 +26,7 @@ type MdmDeviceAssignmentModel struct {
 	ID                types.String               `tfsdk:"id"`
 	Name              types.String               `tfsdk:"name"`
 	Type              types.String               `tfsdk:"type"`
-	EnableMdmDisown   types.Bool                 `tfsdk:"enable_mdm_disown"`
+	AllowRelease      types.Bool                 `tfsdk:"allow_release"`
 	ServerCertificate *MdmServerCertificateModel `tfsdk:"server_certificate"`
 	Timeouts          timeouts.Value             `tfsdk:"timeouts"`
 	DeviceIDs         types.Set                  `tfsdk:"device_ids"`

--- a/internal/resources/device_management_service/resource.go
+++ b/internal/resources/device_management_service/resource.go
@@ -68,10 +68,10 @@ func (r *DeviceManagementServiceResource) Schema(ctx context.Context, req resour
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"enable_mdm_disown": schema.BoolAttribute{
+			"allow_release": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "When true, devices can be released from MDM without being removed from Apple Business Manager.",
+				Description: "Allow this service to release devices.",
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/resources/device_management_service/resource_test.go
+++ b/internal/resources/device_management_service/resource_test.go
@@ -142,7 +142,7 @@ func TestResourceSchema(t *testing.T) {
 		{"id", false, false, true},
 		{"name", true, false, false},
 		{"type", false, false, true},
-		{"enable_mdm_disown", false, true, true},
+		{"allow_release", false, true, true},
 		{"device_ids", false, true, true},
 		{"timeouts", false, true, false},
 	}


### PR DESCRIPTION
## Summary

- Renames `enable_mdm_disown` to `allow_release` to match the Apple Business Manager UI label ("Allow this service to release devices")
- Fixes `Provider produced inconsistent result after apply` error caused by Apple's create response echoing `enableMdmDisownFlag: false` regardless of the value sent — the provider now keeps the plan value after create and lets `Read` reconcile on the next refresh

## Test plan

- [x] `terraform apply` with `allow_release = true` no longer errors with inconsistent result
- [x] `terraform apply` with `allow_release = false` works as before
- [x] `terraform plan` after apply shows no drift for `allow_release`
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)