### PR TITLE
docs: align data source descriptions with Apple API spec

### DIFF
--- a/docs/data-sources/apple_device_management_device.md
+++ b/docs/data-sources/apple_device_management_device.md
@@ -3,12 +3,12 @@
 page_title: "axm_apple_device_management_device Data Source - terraform-provider-axm"
 subcategory: ""
 description: |-
-  Fetches detailed information about a specific Apple device enrolled in a device management service.
+  Get detailed information about a device enrolled in Apple Device Management service.
 ---
 
 # axm_apple_device_management_device (Data Source)
 
-Fetches detailed information about a specific Apple device enrolled in a device management service.
+Get detailed information about a device enrolled in Apple Device Management service.
 
 ## Example Usage
 

--- a/docs/data-sources/apple_device_management_devices.md
+++ b/docs/data-sources/apple_device_management_devices.md
@@ -3,12 +3,12 @@
 page_title: "axm_apple_device_management_devices Data Source - terraform-provider-axm"
 subcategory: ""
 description: |-
-  Fetches the list of Apple devices enrolled in a device management service.
+  Get a list of devices enrolled in Apple Device Management service.
 ---
 
 # axm_apple_device_management_devices (Data Source)
 
-Fetches the list of Apple devices enrolled in a device management service.
+Get a list of devices enrolled in Apple Device Management service.
 
 ## Example Usage
 

--- a/internal/resources/apple_device_management_device/data_source.go
+++ b/internal/resources/apple_device_management_device/data_source.go
@@ -60,7 +60,7 @@ func (d *AppleDeviceManagementDeviceDataSource) Metadata(ctx context.Context, re
 
 func (d *AppleDeviceManagementDeviceDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Fetches detailed information about a specific Apple device enrolled in a device management service.",
+		Description: "Get detailed information about a device enrolled in Apple Device Management service.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Required:    true,

--- a/internal/resources/apple_device_management_devices/data_source.go
+++ b/internal/resources/apple_device_management_devices/data_source.go
@@ -53,7 +53,7 @@ func (d *AppleDeviceManagementDevicesDataSource) Metadata(ctx context.Context, r
 
 func (d *AppleDeviceManagementDevicesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Fetches the list of Apple devices enrolled in a device management service.",
+		Description: "Get a list of devices enrolled in Apple Device Management service.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Identifier of the data source.",


### PR DESCRIPTION
Updates the descriptions for both MDM device data sources to match Apple's API specification verbatim:

- **axm_apple_device_management_devices**: "Get a list of devices enrolled in Apple Device Management service."
- **axm_apple_device_management_device**: "Get detailed information about a device enrolled in Apple Device Management service."

Also regenerates the documentation to reflect these changes.