### PR TITLE
test: fill unit test gaps and align schema descriptions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '29 11 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: go
+          build-mode: autobuild
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -37,7 +37,7 @@ output "example_app" {
 
 - `app_store_url` (String) The App Store URL.
 - `bundle_id` (String) The app bundle identifier.
-- `is_custom_app` (Boolean) Whether the app is custom.
+- `is_custom_app` (Boolean) Indicates whether this is a custom B2B app.
 - `name` (String) The app name.
 - `supported_os` (List of String) Supported operating systems.
 - `type` (String) The resource type.

--- a/docs/data-sources/apps.md
+++ b/docs/data-sources/apps.md
@@ -48,7 +48,7 @@ Read-Only:
 - `app_store_url` (String) The App Store URL.
 - `bundle_id` (String) The app bundle identifier.
 - `id` (String) The app ID.
-- `is_custom_app` (Boolean) Whether the app is custom.
+- `is_custom_app` (Boolean) Indicates whether this is a custom B2B app.
 - `name` (String) The app name.
 - `supported_os` (List of String) Supported operating systems.
 - `type` (String) The resource type.

--- a/docs/data-sources/audit_events.md
+++ b/docs/data-sources/audit_events.md
@@ -28,17 +28,17 @@ output "example_audit_events" {
 
 ### Required
 
-- `end_timestamp` (String) ISO8601 end timestamp for the query range.
-- `start_timestamp` (String) ISO8601 start timestamp for the query range.
+- `end_timestamp` (String) ISO8601 end timestamp for the query range (UTC).
+- `start_timestamp` (String) ISO8601 start timestamp for the query range (UTC).
 
 ### Optional
 
-- `actor_id` (String) Actor ID to filter by.
+- `actor_id` (String) Unique identifier of the actor to filter by.
 - `cursor` (String) Pagination cursor for the first page.
-- `event_type` (String) Event type to filter by.
+- `event_type` (String) The type of event to filter by.
 - `fields` (List of String) Fields to include in the response.
 - `limit` (Number) Maximum number of events to request per page.
-- `subject_id` (String) Subject ID to filter by.
+- `subject_id` (String) Unique identifier of the subject to filter by.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -59,18 +59,18 @@ Optional:
 
 Read-Only:
 
-- `actor_id` (String) The actor ID.
-- `actor_name` (String) The actor name.
-- `actor_type` (String) The actor type.
-- `category` (String) The event category.
+- `actor_id` (String) Unique identifier of the actor.
+- `actor_name` (String) Display name of the actor.
+- `actor_type` (String) The type of entity that performed the action.
+- `category` (String) The category of the event.
 - `event_data_json` (String) JSON payload for event-specific data.
-- `event_data_property_key` (String) The event data property key.
-- `event_date_time` (String) Timestamp when the event occurred.
-- `event_type` (String) The event type.
-- `group_id` (String) The event group ID.
-- `id` (String) The audit event ID.
-- `outcome` (String) The outcome of the event.
-- `subject_id` (String) The subject ID.
-- `subject_name` (String) The subject name.
-- `subject_type` (String) The subject type.
+- `event_data_property_key` (String) Property key for event-specific data.
+- `event_date_time` (String) Timestamp when the event occurred (ISO8601 format, UTC).
+- `event_type` (String) The type of event that occurred.
+- `group_id` (String) Identifier for grouping related events.
+- `id` (String) The opaque resource ID that uniquely identifies the resource.
+- `outcome` (String) The result of the action.
+- `subject_id` (String) Unique identifier of the subject.
+- `subject_name` (String) Display name of the subject.
+- `subject_type` (String) The type of entity that was affected.
 - `type` (String) The resource type.

--- a/docs/data-sources/blueprint.md
+++ b/docs/data-sources/blueprint.md
@@ -33,7 +33,7 @@ Fetches information about a specific Blueprint from Apple Business Manager.
 - `device_ids` (Set of String) Device IDs associated with the Blueprint.
 - `name` (String) The Blueprint name.
 - `package_ids` (Set of String) Package IDs associated with the Blueprint.
-- `status` (String) The Blueprint status.
+- `status` (String) The current status of the Blueprint.
 - `updated_date_time` (String) The date and time the Blueprint was last updated.
 - `user_group_ids` (Set of String) User group IDs associated with the Blueprint.
 - `user_ids` (Set of String) User IDs associated with the Blueprint.

--- a/docs/data-sources/blueprints.md
+++ b/docs/data-sources/blueprints.md
@@ -42,5 +42,5 @@ Read-Only:
 - `description` (String) The Blueprint description.
 - `id` (String) The Blueprint ID.
 - `name` (String) The Blueprint name.
-- `status` (String) The Blueprint status.
+- `status` (String) The current status of the Blueprint.
 - `updated_date_time` (String) The date and time the Blueprint was last updated.

--- a/docs/data-sources/configuration.md
+++ b/docs/data-sources/configuration.md
@@ -25,11 +25,11 @@ Fetches information about a specific configuration from Apple Business Manager.
 
 ### Read-Only
 
-- `configuration_profile` (String) The configuration profile payload. Only present for CUSTOM_SETTING configurations.
+- `configuration_profile` (String) The XML content of the configuration profile in Apple .plist format. Only present for CUSTOM_SETTING configurations.
 - `configuration_type` (String) The configuration type (e.g. AIR_DROP, AUTHENTICATION_SCREEN_LOCK, CUSTOM_SETTING).
 - `configured_for_platforms` (List of String) Platforms the configuration applies to.
 - `created_date_time` (String) The created date and time.
-- `filename` (String) The configuration profile filename. Only present for CUSTOM_SETTING configurations.
+- `filename` (String) The filename for the configuration profile (for example, Settings.mobileconfig). Only present for CUSTOM_SETTING configurations.
 - `name` (String) The configuration name.
 - `type` (String) The resource type.
 - `updated_date_time` (String) The updated date and time.

--- a/docs/data-sources/organization_device.md
+++ b/docs/data-sources/organization_device.md
@@ -52,6 +52,8 @@ output "example_device" {
 - `purchase_source_id` (String) The unique ID of the purchase source type: Apple Customer Number or Reseller Number.
 - `purchase_source_type` (String) The type of the purchase source.
 - `released_from_org_date_time` (String) The date and time the device was released from an organization. This will be null if the device hasn't been released. Currently only querying by a single device is supported. Batch device queries aren't currently supported for this property.
+- `releaser_entity_type` (String) The type of entity that released the device from the organization.
+- `releaser_id` (String) The ID of the entity that released the device from the organization.
 - `serial_number` (String) The device's serial number.
 - `status` (String) The device's status: ASSIGNED or UNASSIGNED. If ASSIGNED, use a separate API to get the information of the assigned server.
 - `type` (String) The type of the device.

--- a/docs/data-sources/organization_devices.md
+++ b/docs/data-sources/organization_devices.md
@@ -66,6 +66,8 @@ Read-Only:
 - `purchase_source_id` (String) The unique ID of the purchase source type: Apple Customer Number or Reseller Number.
 - `purchase_source_type` (String) The type of the purchase source.
 - `released_from_org_date_time` (String) The date and time the device was released from an organization. This will be null if the device hasn't been released. Currently only querying by a single device is supported. Batch device queries aren't currently supported for this property.
+- `releaser_entity_type` (String) The type of entity that released the device from the organization.
+- `releaser_id` (String) The ID of the entity that released the device from the organization.
 - `serial_number` (String) The device's serial number.
 - `status` (String) The device's status: ASSIGNED or UNASSIGNED. If ASSIGNED, use a separate API to get the information of the assigned server.
 - `type` (String) The type of the device.

--- a/docs/data-sources/package.md
+++ b/docs/data-sources/package.md
@@ -38,11 +38,11 @@ output "example_package" {
 - `bundle_ids` (List of String) Bundle IDs in the package.
 - `created_date_time` (String) The created date and time.
 - `description` (String) The package description.
-- `hash` (String) The package hash.
+- `hash` (String) The hex string hash of the package file.
 - `name` (String) The package name.
 - `type` (String) The resource type.
 - `updated_date_time` (String) The updated date and time.
-- `url` (String) The package URL.
+- `url` (String) The HTTPS URL to download the package.
 - `version` (String) The package version.
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/data-sources/packages.md
+++ b/docs/data-sources/packages.md
@@ -48,10 +48,10 @@ Read-Only:
 - `bundle_ids` (List of String) Bundle IDs in the package.
 - `created_date_time` (String) The created date and time.
 - `description` (String) The package description.
-- `hash` (String) The package hash.
+- `hash` (String) The hex string hash of the package file.
 - `id` (String) The package ID.
 - `name` (String) The package name.
 - `type` (String) The resource type.
 - `updated_date_time` (String) The updated date and time.
-- `url` (String) The package URL.
+- `url` (String) The HTTPS URL to download the package.
 - `version` (String) The package version.

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -35,24 +35,24 @@ output "example_user" {
 
 ### Read-Only
 
-- `cost_center` (String) The cost center.
-- `created_date_time` (String) The created date and time.
-- `department` (String) The department.
-- `division` (String) The division.
+- `cost_center` (String) The cost center the user belongs to in the organization.
+- `created_date_time` (String) The date and time that the user was created.
+- `department` (String) The department the user belongs to in the organization.
+- `division` (String) The division the user belongs to in the organization.
 - `email` (String) The user's email address.
-- `employee_number` (String) The employee number.
+- `employee_number` (String) The employee number of the user.
 - `first_name` (String) The user's first name.
-- `is_external_user` (Boolean) Whether the user is external.
-- `job_title` (String) The job title.
+- `is_external_user` (Boolean) Indicates if the user is an external user invited to the organization.
+- `job_title` (String) The job title the user holds in the organization.
 - `last_name` (String) The user's last name.
-- `managed_apple_account` (String) The user's managed Apple account.
+- `managed_apple_account` (String) The Apple Account of the user registered in the system.
 - `middle_name` (String) The user's middle name.
 - `phone_numbers` (Attributes List) Phone numbers for the user. (see [below for nested schema](#nestedatt--phone_numbers))
-- `role_ou_list` (Attributes List) Role and organizational unit mappings. (see [below for nested schema](#nestedatt--role_ou_list))
-- `start_date_time` (String) The start date and time.
-- `status` (String) The user's status.
+- `role_ou_list` (Attributes List) A list of role-organizational unit mappings for the user. (see [below for nested schema](#nestedatt--role_ou_list))
+- `start_date_time` (String) The date and time when the user started as part of the organization.
+- `status` (String) The status of the user.
 - `type` (String) The resource type.
-- `updated_date_time` (String) The updated date and time.
+- `updated_date_time` (String) The date and time that the user was last updated.
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/data-sources/user_group.md
+++ b/docs/data-sources/user_group.md
@@ -35,14 +35,14 @@ output "example_user_group" {
 
 ### Read-Only
 
-- `created_date_time` (String) The created date and time.
-- `group_type` (String) The user group type.
-- `name` (String) The user group name.
-- `ou_id` (String) The organizational unit ID.
-- `status` (String) The user group status.
-- `total_member_count` (Number) The total member count.
+- `created_date_time` (String) The date and time the user group was created.
+- `group_type` (String) The type of group.
+- `name` (String) The name of the user group.
+- `ou_id` (String) The identifier of the organizational unit the group belongs to.
+- `status` (String) The status of the group.
+- `total_member_count` (Number) The total number of members in the group.
 - `type` (String) The resource type.
-- `updated_date_time` (String) The updated date and time.
+- `updated_date_time` (String) The date and time the user group was last modified.
 - `user_ids` (List of String) User IDs associated with the group.
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/data-sources/user_groups.md
+++ b/docs/data-sources/user_groups.md
@@ -45,12 +45,12 @@ Optional:
 
 Read-Only:
 
-- `created_date_time` (String) The created date and time.
-- `group_type` (String) The user group type.
+- `created_date_time` (String) The date and time the user group was created.
+- `group_type` (String) The type of group.
 - `id` (String) The user group ID.
-- `name` (String) The user group name.
-- `ou_id` (String) The organizational unit ID.
-- `status` (String) The user group status.
-- `total_member_count` (Number) The total member count.
+- `name` (String) The name of the user group.
+- `ou_id` (String) The identifier of the organizational unit the group belongs to.
+- `status` (String) The status of the group.
+- `total_member_count` (Number) The total number of members in the group.
 - `type` (String) The resource type.
-- `updated_date_time` (String) The updated date and time.
+- `updated_date_time` (String) The date and time the user group was last modified.

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -45,25 +45,25 @@ Optional:
 
 Read-Only:
 
-- `cost_center` (String) The cost center.
-- `created_date_time` (String) The created date and time.
-- `department` (String) The department.
-- `division` (String) The division.
+- `cost_center` (String) The cost center the user belongs to in the organization.
+- `created_date_time` (String) The date and time that the user was created.
+- `department` (String) The department the user belongs to in the organization.
+- `division` (String) The division the user belongs to in the organization.
 - `email` (String) The user's email address.
-- `employee_number` (String) The employee number.
+- `employee_number` (String) The employee number of the user.
 - `first_name` (String) The user's first name.
 - `id` (String) The user ID.
-- `is_external_user` (Boolean) Whether the user is external.
-- `job_title` (String) The job title.
+- `is_external_user` (Boolean) Indicates if the user is an external user invited to the organization.
+- `job_title` (String) The job title the user holds in the organization.
 - `last_name` (String) The user's last name.
-- `managed_apple_account` (String) The user's managed Apple account.
+- `managed_apple_account` (String) The Apple Account of the user registered in the system.
 - `middle_name` (String) The user's middle name.
 - `phone_numbers` (Attributes List) Phone numbers for the user. (see [below for nested schema](#nestedatt--users--phone_numbers))
-- `role_ou_list` (Attributes List) Role and organizational unit mappings. (see [below for nested schema](#nestedatt--users--role_ou_list))
-- `start_date_time` (String) The start date and time.
-- `status` (String) The user's status.
+- `role_ou_list` (Attributes List) A list of role-organizational unit mappings for the user. (see [below for nested schema](#nestedatt--users--role_ou_list))
+- `start_date_time` (String) The date and time when the user started as part of the organization.
+- `status` (String) The status of the user.
 - `type` (String) The resource type.
-- `updated_date_time` (String) The updated date and time.
+- `updated_date_time` (String) The date and time that the user was last updated.
 
 <a id="nestedatt--users--phone_numbers"></a>
 ### Nested Schema for `users.phone_numbers`

--- a/docs/resources/blueprint.md
+++ b/docs/resources/blueprint.md
@@ -66,7 +66,7 @@ resource "axm_blueprint" "example" {
 - `app_license_deficient` (Boolean) Whether the Blueprint is missing app licenses.
 - `created_date_time` (String) The date and time the Blueprint was created.
 - `id` (String) The Blueprint ID.
-- `status` (String) The Blueprint status.
+- `status` (String) The current status of the Blueprint.
 - `updated_date_time` (String) The date and time the Blueprint was last updated.
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/resources/configuration.md
+++ b/docs/resources/configuration.md
@@ -50,9 +50,9 @@ EOF
 
 ### Optional
 
-- `configuration_profile` (String) The configuration profile payload (mobileconfig XML). Required for CUSTOM_SETTING configurations.
+- `configuration_profile` (String) The XML content of the configuration profile in Apple .plist format. Required for CUSTOM_SETTING configurations.
 - `configured_for_platforms` (Set of String) Platforms that the Configuration targets.
-- `filename` (String) Filename for the configuration profile. Required for CUSTOM_SETTING configurations.
+- `filename` (String) The filename for the configuration profile (for example, Settings.mobileconfig). Required for CUSTOM_SETTING configurations.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/internal/resources/app/data_source.go
+++ b/internal/resources/app/data_source.go
@@ -82,7 +82,7 @@ func (d *AppDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			},
 			"is_custom_app": schema.BoolAttribute{
 				Computed:    true,
-				Description: "Whether the app is custom.",
+				Description: "Indicates whether this is a custom B2B app.",
 			},
 			"app_store_url": schema.StringAttribute{
 				Computed:    true,

--- a/internal/resources/apps/data_source.go
+++ b/internal/resources/apps/data_source.go
@@ -98,7 +98,7 @@ func (d *AppsDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 						},
 						"is_custom_app": schema.BoolAttribute{
 							Computed:    true,
-							Description: "Whether the app is custom.",
+							Description: "Indicates whether this is a custom B2B app.",
 						},
 						"app_store_url": schema.StringAttribute{
 							Computed:    true,

--- a/internal/resources/audit_events/data_source.go
+++ b/internal/resources/audit_events/data_source.go
@@ -82,23 +82,23 @@ func (d *AuditEventsDataSource) Schema(ctx context.Context, req datasource.Schem
 			"timeouts": timeouts.Attributes(ctx),
 			"start_timestamp": schema.StringAttribute{
 				Required:    true,
-				Description: "ISO8601 start timestamp for the query range.",
+				Description: "ISO8601 start timestamp for the query range (UTC).",
 			},
 			"end_timestamp": schema.StringAttribute{
 				Required:    true,
-				Description: "ISO8601 end timestamp for the query range.",
+				Description: "ISO8601 end timestamp for the query range (UTC).",
 			},
 			"actor_id": schema.StringAttribute{
 				Optional:    true,
-				Description: "Actor ID to filter by.",
+				Description: "Unique identifier of the actor to filter by.",
 			},
 			"subject_id": schema.StringAttribute{
 				Optional:    true,
-				Description: "Subject ID to filter by.",
+				Description: "Unique identifier of the subject to filter by.",
 			},
 			"event_type": schema.StringAttribute{
 				Optional:    true,
-				Description: "Event type to filter by.",
+				Description: "The type of event to filter by.",
 			},
 			"limit": schema.Int64Attribute{
 				Optional:    true,
@@ -120,7 +120,7 @@ func (d *AuditEventsDataSource) Schema(ctx context.Context, req datasource.Schem
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
 							Computed:    true,
-							Description: "The audit event ID.",
+							Description: "The opaque resource ID that uniquely identifies the resource.",
 						},
 						"type": schema.StringAttribute{
 							Computed:    true,
@@ -128,51 +128,51 @@ func (d *AuditEventsDataSource) Schema(ctx context.Context, req datasource.Schem
 						},
 						"event_date_time": schema.StringAttribute{
 							Computed:    true,
-							Description: "Timestamp when the event occurred.",
+							Description: "Timestamp when the event occurred (ISO8601 format, UTC).",
 						},
 						"event_type": schema.StringAttribute{
 							Computed:    true,
-							Description: "The event type.",
+							Description: "The type of event that occurred.",
 						},
 						"category": schema.StringAttribute{
 							Computed:    true,
-							Description: "The event category.",
+							Description: "The category of the event.",
 						},
 						"actor_type": schema.StringAttribute{
 							Computed:    true,
-							Description: "The actor type.",
+							Description: "The type of entity that performed the action.",
 						},
 						"actor_id": schema.StringAttribute{
 							Computed:    true,
-							Description: "The actor ID.",
+							Description: "Unique identifier of the actor.",
 						},
 						"actor_name": schema.StringAttribute{
 							Computed:    true,
-							Description: "The actor name.",
+							Description: "Display name of the actor.",
 						},
 						"subject_type": schema.StringAttribute{
 							Computed:    true,
-							Description: "The subject type.",
+							Description: "The type of entity that was affected.",
 						},
 						"subject_id": schema.StringAttribute{
 							Computed:    true,
-							Description: "The subject ID.",
+							Description: "Unique identifier of the subject.",
 						},
 						"subject_name": schema.StringAttribute{
 							Computed:    true,
-							Description: "The subject name.",
+							Description: "Display name of the subject.",
 						},
 						"outcome": schema.StringAttribute{
 							Computed:    true,
-							Description: "The outcome of the event.",
+							Description: "The result of the action.",
 						},
 						"group_id": schema.StringAttribute{
 							Computed:    true,
-							Description: "The event group ID.",
+							Description: "Identifier for grouping related events.",
 						},
 						"event_data_property_key": schema.StringAttribute{
 							Computed:    true,
-							Description: "The event data property key.",
+							Description: "Property key for event-specific data.",
 						},
 						"event_data_json": schema.StringAttribute{
 							Computed:    true,

--- a/internal/resources/audit_events/data_source_test.go
+++ b/internal/resources/audit_events/data_source_test.go
@@ -71,7 +71,15 @@ func TestAuditEventsDataSourceSchema(t *testing.T) {
 		t.Error("expected 'events' to be Computed")
 	}
 
-	if _, ok := eventsAttr.NestedObject.Attributes["event_data_json"]; !ok {
-		t.Error("nested attribute 'event_data_json' not found in events")
+	allNested := []string{
+		"id", "type", "event_date_time", "event_type", "category",
+		"actor_type", "actor_id", "actor_name", "subject_type",
+		"subject_id", "subject_name", "outcome", "group_id",
+		"event_data_property_key", "event_data_json",
+	}
+	for _, name := range allNested {
+		if _, ok := eventsAttr.NestedObject.Attributes[name]; !ok {
+			t.Errorf("nested attribute %q not found in events", name)
+		}
 	}
 }

--- a/internal/resources/audit_events/helpers_test.go
+++ b/internal/resources/audit_events/helpers_test.go
@@ -1,0 +1,132 @@
+// Copyright Neil Martin 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package audit_events
+
+import (
+	"testing"
+
+	"github.com/neilmartin83/terraform-provider-axm/internal/client"
+)
+
+func TestFlattenAuditEvent(t *testing.T) {
+	event := client.AuditEvent{
+		ID:   "event-1",
+		Type: "auditEvent",
+		Attributes: client.AuditEventAttributes{
+			EventDateTime:        "2024-06-01T12:00:00Z",
+			Type:                 "USER_CREATED",
+			Category:             "USER",
+			ActorType:            "admin",
+			ActorID:              "actor-1",
+			ActorName:            "Admin User",
+			SubjectType:          "user",
+			SubjectID:            "subject-1",
+			SubjectName:          "Target User",
+			Outcome:              "SUCCESS",
+			GroupID:              "group-1",
+			EventDataPropertyKey: "userId",
+			Additional: map[string]any{
+				"userId": "subject-1",
+			},
+		},
+	}
+
+	model := flattenAuditEvent(event)
+
+	if model.ID.ValueString() != "event-1" {
+		t.Errorf("expected ID event-1, got %s", model.ID.ValueString())
+	}
+	if model.Type.ValueString() != "auditEvent" {
+		t.Errorf("expected Type auditEvent, got %s", model.Type.ValueString())
+	}
+	if model.EventDateTime.ValueString() != "2024-06-01T12:00:00Z" {
+		t.Errorf("expected EventDateTime 2024-06-01T12:00:00Z, got %s", model.EventDateTime.ValueString())
+	}
+	if model.EventType.ValueString() != "USER_CREATED" {
+		t.Errorf("expected EventType USER_CREATED, got %s", model.EventType.ValueString())
+	}
+	if model.Category.ValueString() != "USER" {
+		t.Errorf("expected Category USER, got %s", model.Category.ValueString())
+	}
+	if model.ActorType.ValueString() != "admin" {
+		t.Errorf("expected ActorType admin, got %s", model.ActorType.ValueString())
+	}
+	if model.ActorID.ValueString() != "actor-1" {
+		t.Errorf("expected ActorID actor-1, got %s", model.ActorID.ValueString())
+	}
+	if model.ActorName.ValueString() != "Admin User" {
+		t.Errorf("expected ActorName Admin User, got %s", model.ActorName.ValueString())
+	}
+	if model.SubjectType.ValueString() != "user" {
+		t.Errorf("expected SubjectType user, got %s", model.SubjectType.ValueString())
+	}
+	if model.SubjectID.ValueString() != "subject-1" {
+		t.Errorf("expected SubjectID subject-1, got %s", model.SubjectID.ValueString())
+	}
+	if model.SubjectName.ValueString() != "Target User" {
+		t.Errorf("expected SubjectName Target User, got %s", model.SubjectName.ValueString())
+	}
+	if model.Outcome.ValueString() != "SUCCESS" {
+		t.Errorf("expected Outcome SUCCESS, got %s", model.Outcome.ValueString())
+	}
+	if model.GroupID.ValueString() != "group-1" {
+		t.Errorf("expected GroupID group-1, got %s", model.GroupID.ValueString())
+	}
+	if model.EventDataPropertyKey.ValueString() != "userId" {
+		t.Errorf("expected EventDataPropertyKey userId, got %s", model.EventDataPropertyKey.ValueString())
+	}
+	if model.EventDataJSON.ValueString() == "" {
+		t.Error("expected non-empty EventDataJSON")
+	}
+}
+
+func TestFlattenAuditEvent_EmptyOptionalFields(t *testing.T) {
+	event := client.AuditEvent{
+		ID:         "event-2",
+		Type:       "auditEvent",
+		Attributes: client.AuditEventAttributes{},
+	}
+
+	model := flattenAuditEvent(event)
+
+	if !model.EventDateTime.IsNull() {
+		t.Error("expected EventDateTime to be null when empty")
+	}
+	if !model.EventType.IsNull() {
+		t.Error("expected EventType to be null when empty")
+	}
+	if !model.Category.IsNull() {
+		t.Error("expected Category to be null when empty")
+	}
+	if !model.ActorType.IsNull() {
+		t.Error("expected ActorType to be null when empty")
+	}
+	if !model.ActorID.IsNull() {
+		t.Error("expected ActorID to be null when empty")
+	}
+	if !model.ActorName.IsNull() {
+		t.Error("expected ActorName to be null when empty")
+	}
+	if !model.SubjectType.IsNull() {
+		t.Error("expected SubjectType to be null when empty")
+	}
+	if !model.SubjectID.IsNull() {
+		t.Error("expected SubjectID to be null when empty")
+	}
+	if !model.SubjectName.IsNull() {
+		t.Error("expected SubjectName to be null when empty")
+	}
+	if !model.Outcome.IsNull() {
+		t.Error("expected Outcome to be null when empty")
+	}
+	if !model.GroupID.IsNull() {
+		t.Error("expected GroupID to be null when empty")
+	}
+	if !model.EventDataPropertyKey.IsNull() {
+		t.Error("expected EventDataPropertyKey to be null when empty")
+	}
+	if model.EventDataJSON.ValueString() != "null" {
+		t.Errorf("expected EventDataJSON to be 'null' when Additional is nil, got %q", model.EventDataJSON.ValueString())
+	}
+}

--- a/internal/resources/blueprint/data_source.go
+++ b/internal/resources/blueprint/data_source.go
@@ -71,7 +71,7 @@ func (d *BlueprintDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			},
 			"status": schema.StringAttribute{
 				Computed:    true,
-				Description: "The Blueprint status.",
+				Description: "The current status of the Blueprint.",
 			},
 			"app_license_deficient": schema.BoolAttribute{
 				Computed:    true,

--- a/internal/resources/blueprint/helpers_test.go
+++ b/internal/resources/blueprint/helpers_test.go
@@ -1,0 +1,92 @@
+// Copyright Neil Martin 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package blueprint
+
+import (
+	"testing"
+)
+
+func TestBuildRelationshipData(t *testing.T) {
+	t.Run("multiple_ids", func(t *testing.T) {
+		data := buildRelationshipData("apps", []string{"id1", "id2"})
+
+		if len(data) != 2 {
+			t.Fatalf("expected 2 items, got %d", len(data))
+		}
+		if data[0].Type != "apps" {
+			t.Errorf("expected type apps, got %s", data[0].Type)
+		}
+		if data[0].ID != "id1" {
+			t.Errorf("expected id id1, got %s", data[0].ID)
+		}
+		if data[1].ID != "id2" {
+			t.Errorf("expected id id2, got %s", data[1].ID)
+		}
+	})
+
+	t.Run("empty_ids", func(t *testing.T) {
+		data := buildRelationshipData("apps", []string{})
+
+		if len(data) != 0 {
+			t.Errorf("expected 0 items, got %d", len(data))
+		}
+	})
+}
+
+func TestDiffIDs(t *testing.T) {
+	t.Run("add_and_remove", func(t *testing.T) {
+		toAdd, toRemove := diffIDs([]string{"a", "b"}, []string{"b", "c"})
+
+		if len(toAdd) != 1 || toAdd[0] != "c" {
+			t.Errorf("expected toAdd [c], got %v", toAdd)
+		}
+		if len(toRemove) != 1 || toRemove[0] != "a" {
+			t.Errorf("expected toRemove [a], got %v", toRemove)
+		}
+	})
+
+	t.Run("no_changes", func(t *testing.T) {
+		toAdd, toRemove := diffIDs([]string{"a", "b"}, []string{"a", "b"})
+
+		if len(toAdd) != 0 {
+			t.Errorf("expected empty toAdd, got %v", toAdd)
+		}
+		if len(toRemove) != 0 {
+			t.Errorf("expected empty toRemove, got %v", toRemove)
+		}
+	})
+
+	t.Run("all_new", func(t *testing.T) {
+		toAdd, toRemove := diffIDs([]string{}, []string{"a", "b"})
+
+		if len(toAdd) != 2 {
+			t.Errorf("expected 2 toAdd, got %v", toAdd)
+		}
+		if len(toRemove) != 0 {
+			t.Errorf("expected empty toRemove, got %v", toRemove)
+		}
+	})
+
+	t.Run("all_removed", func(t *testing.T) {
+		toAdd, toRemove := diffIDs([]string{"a", "b"}, []string{})
+
+		if len(toAdd) != 0 {
+			t.Errorf("expected empty toAdd, got %v", toAdd)
+		}
+		if len(toRemove) != 2 {
+			t.Errorf("expected 2 toRemove, got %v", toRemove)
+		}
+	})
+
+	t.Run("duplicates_in_current", func(t *testing.T) {
+		toAdd, toRemove := diffIDs([]string{"a", "a", "b"}, []string{"a"})
+
+		if len(toAdd) != 0 {
+			t.Errorf("expected empty toAdd, got %v", toAdd)
+		}
+		if len(toRemove) != 1 || toRemove[0] != "b" {
+			t.Errorf("expected toRemove [b], got %v", toRemove)
+		}
+	})
+}

--- a/internal/resources/blueprint/resource.go
+++ b/internal/resources/blueprint/resource.go
@@ -60,7 +60,7 @@ func (r *BlueprintResource) Schema(ctx context.Context, req resource.SchemaReque
 			},
 			"status": schema.StringAttribute{
 				Computed:    true,
-				Description: "The Blueprint status.",
+				Description: "The current status of the Blueprint.",
 			},
 			"app_license_deficient": schema.BoolAttribute{
 				Computed:    true,

--- a/internal/resources/blueprints/data_source.go
+++ b/internal/resources/blueprints/data_source.go
@@ -79,7 +79,7 @@ func (d *BlueprintsDataSource) Schema(ctx context.Context, req datasource.Schema
 						},
 						"status": schema.StringAttribute{
 							Computed:    true,
-							Description: "The Blueprint status.",
+							Description: "The current status of the Blueprint.",
 						},
 						"app_license_deficient": schema.BoolAttribute{
 							Computed:    true,

--- a/internal/resources/blueprints/data_source_test.go
+++ b/internal/resources/blueprints/data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
 	"github.com/neilmartin83/terraform-provider-axm/internal/resources/blueprints"
 )
@@ -31,13 +32,38 @@ func TestBlueprintsDataSourceSchema(t *testing.T) {
 		t.Error("expected non-empty schema Description")
 	}
 
-	if _, ok := resp.Schema.Attributes["id"]; !ok {
+	idAttr, ok := resp.Schema.Attributes["id"]
+	if !ok {
 		t.Fatal("attribute 'id' not found")
 	}
+	if !idAttr.IsComputed() {
+		t.Error("expected 'id' to be Computed")
+	}
+
 	if _, ok := resp.Schema.Attributes["timeouts"]; !ok {
 		t.Fatal("attribute 'timeouts' not found")
 	}
-	if _, ok := resp.Schema.Attributes["blueprints"]; !ok {
-		t.Fatal("attribute 'blueprints' not found")
+
+	blueprintsAttr, ok := resp.Schema.Attributes["blueprints"].(dsschema.ListNestedAttribute)
+	if !ok {
+		t.Fatal("expected 'blueprints' to be a ListNestedAttribute")
+	}
+	if !blueprintsAttr.IsComputed() {
+		t.Error("expected 'blueprints' to be Computed")
+	}
+
+	nestedAttrs := blueprintsAttr.NestedObject.Attributes
+	allExpectedNested := []string{
+		"id", "name", "description", "status",
+		"app_license_deficient", "created_date_time", "updated_date_time",
+	}
+	for _, name := range allExpectedNested {
+		if _, ok := nestedAttrs[name]; !ok {
+			t.Errorf("nested attribute %q not found in blueprints", name)
+		}
+	}
+
+	if _, ok := nestedAttrs["app_license_deficient"].(dsschema.BoolAttribute); !ok {
+		t.Error("expected 'app_license_deficient' to be a BoolAttribute")
 	}
 }

--- a/internal/resources/configuration/data_source.go
+++ b/internal/resources/configuration/data_source.go
@@ -74,11 +74,11 @@ func (d *ConfigurationDataSource) Schema(ctx context.Context, req datasource.Sch
 			},
 			"configuration_profile": schema.StringAttribute{
 				Computed:    true,
-				Description: "The configuration profile payload. Only present for CUSTOM_SETTING configurations.",
+				Description: "The XML content of the configuration profile in Apple .plist format. Only present for CUSTOM_SETTING configurations.",
 			},
 			"filename": schema.StringAttribute{
 				Computed:    true,
-				Description: "The configuration profile filename. Only present for CUSTOM_SETTING configurations.",
+				Description: "The filename for the configuration profile (for example, Settings.mobileconfig). Only present for CUSTOM_SETTING configurations.",
 			},
 			"created_date_time": schema.StringAttribute{
 				Computed:    true,

--- a/internal/resources/configuration/resource.go
+++ b/internal/resources/configuration/resource.go
@@ -68,12 +68,12 @@ func (r *ConfigurationResource) Schema(ctx context.Context, req resource.SchemaR
 			"configuration_profile": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "The configuration profile payload (mobileconfig XML). Required for CUSTOM_SETTING configurations.",
+				Description: "The XML content of the configuration profile in Apple .plist format. Required for CUSTOM_SETTING configurations.",
 			},
 			"filename": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Filename for the configuration profile. Required for CUSTOM_SETTING configurations.",
+				Description: "The filename for the configuration profile (for example, Settings.mobileconfig). Required for CUSTOM_SETTING configurations.",
 			},
 			"created_date_time": schema.StringAttribute{
 				Computed:    true,

--- a/internal/resources/default_device_assignment/crud_test.go
+++ b/internal/resources/default_device_assignment/crud_test.go
@@ -1,0 +1,133 @@
+// Copyright Neil Martin 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package default_device_assignment
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFamilyServerMap(t *testing.T) {
+	data := DefaultDeviceAssignmentModel{
+		AppleTV: types.StringValue("srv-1"),
+		IPad:    types.StringValue("srv-2"),
+		Mac:     types.StringValue("srv-1"),
+	}
+
+	m := familyServerMap(data)
+
+	if m["APPLE_TV"] != "srv-1" {
+		t.Errorf("expected APPLE_TV -> srv-1, got %q", m["APPLE_TV"])
+	}
+	if m["IPAD"] != "srv-2" {
+		t.Errorf("expected IPAD -> srv-2, got %q", m["IPAD"])
+	}
+	if m["MAC"] != "srv-1" {
+		t.Errorf("expected MAC -> srv-1, got %q", m["MAC"])
+	}
+
+	nullKeys := []string{"IPHONE", "IPOD", "VISION", "WATCH"}
+	for _, k := range nullKeys {
+		if _, ok := m[k]; ok {
+			t.Errorf("expected %q to be omitted for null values", k)
+		}
+	}
+}
+
+func TestFamilyServerMap_EmptyString(t *testing.T) {
+	data := DefaultDeviceAssignmentModel{
+		AppleTV: types.StringValue(""),
+		IPad:    types.StringValue("srv-2"),
+	}
+
+	m := familyServerMap(data)
+
+	if m["APPLE_TV"] != "" {
+		t.Errorf("expected APPLE_TV -> \"\", got %q", m["APPLE_TV"])
+	}
+}
+
+func TestUniqueServerIDs(t *testing.T) {
+	data := DefaultDeviceAssignmentModel{
+		AppleTV: types.StringValue("srv-1"),
+		IPad:    types.StringValue("srv-2"),
+		Mac:     types.StringValue("srv-1"),
+	}
+
+	ids := uniqueServerIDs(data)
+
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 unique IDs, got %d", len(ids))
+	}
+	if _, ok := ids["srv-1"]; !ok {
+		t.Error("expected srv-1 in unique IDs")
+	}
+	if _, ok := ids["srv-2"]; !ok {
+		t.Error("expected srv-2 in unique IDs")
+	}
+}
+
+func TestUniqueServerIDs_SkipsNullUnknownEmpty(t *testing.T) {
+	data := DefaultDeviceAssignmentModel{
+		AppleTV: types.StringNull(),
+		IPad:    types.StringUnknown(),
+		Mac:     types.StringValue(""),
+	}
+
+	ids := uniqueServerIDs(data)
+
+	if len(ids) != 0 {
+		t.Errorf("expected 0 unique IDs, got %d", len(ids))
+	}
+}
+
+func TestReconcileFamily(t *testing.T) {
+	current := map[string]string{
+		"IPAD": "srv-1",
+		"MAC":  "srv-2",
+	}
+
+	t.Run("null_field", func(t *testing.T) {
+		result := reconcileFamily(types.StringNull(), "IPAD", current)
+		if !result.IsNull() {
+			t.Error("expected null result for null input")
+		}
+	})
+
+	t.Run("unknown_field", func(t *testing.T) {
+		result := reconcileFamily(types.StringUnknown(), "IPAD", current)
+		if !result.IsUnknown() {
+			t.Error("expected unknown result for unknown input")
+		}
+	})
+
+	t.Run("empty_sentinel", func(t *testing.T) {
+		result := reconcileFamily(types.StringValue(""), "IPAD", current)
+		if result.ValueString() != "" {
+			t.Errorf("expected empty string, got %q", result.ValueString())
+		}
+	})
+
+	t.Run("server_still_holds_family", func(t *testing.T) {
+		result := reconcileFamily(types.StringValue("srv-1"), "IPAD", current)
+		if result.ValueString() != "srv-1" {
+			t.Errorf("expected srv-1, got %q", result.ValueString())
+		}
+	})
+
+	t.Run("server_no_longer_holds_family", func(t *testing.T) {
+		result := reconcileFamily(types.StringValue("srv-1"), "MAC", current)
+		if !result.IsNull() {
+			t.Errorf("expected null result when server no longer holds family, got %q", result.ValueString())
+		}
+	})
+
+	t.Run("family_not_in_current", func(t *testing.T) {
+		result := reconcileFamily(types.StringValue("srv-3"), "IPHONE", current)
+		if !result.IsNull() {
+			t.Errorf("expected null result when family not in current map")
+		}
+	})
+}

--- a/internal/resources/default_device_assignment/resource_test.go
+++ b/internal/resources/default_device_assignment/resource_test.go
@@ -1,0 +1,79 @@
+// Copyright Neil Martin 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package default_device_assignment_test
+
+import (
+	"context"
+	"testing"
+
+	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/neilmartin83/terraform-provider-axm/internal/resources/default_device_assignment"
+)
+
+func TestDefaultDeviceAssignmentResourceMetadata(t *testing.T) {
+	r := default_device_assignment.NewDefaultDeviceAssignmentResource()
+	resp := tfresource.MetadataResponse{}
+	r.Metadata(context.Background(), tfresource.MetadataRequest{ProviderTypeName: "axm"}, &resp)
+
+	if resp.TypeName != "axm_default_device_assignment" {
+		t.Errorf("expected TypeName %q, got %q", "axm_default_device_assignment", resp.TypeName)
+	}
+}
+
+func TestDefaultDeviceAssignmentResourceSchema(t *testing.T) {
+	r := default_device_assignment.NewDefaultDeviceAssignmentResource()
+	resp := tfresource.SchemaResponse{}
+	r.Schema(context.Background(), tfresource.SchemaRequest{}, &resp)
+
+	if resp.Schema.Description == "" {
+		t.Error("expected non-empty schema Description")
+	}
+
+	tests := []struct {
+		name     string
+		required bool
+		optional bool
+		computed bool
+	}{
+		{"id", false, false, true},
+		{"apple_tv", false, true, false},
+		{"apple_vision_pro", false, true, false},
+		{"ipad", false, true, false},
+		{"iphone", false, true, false},
+		{"ipod", false, true, false},
+		{"mac", false, true, false},
+		{"watch", false, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr, ok := resp.Schema.Attributes[tt.name]
+			if !ok {
+				t.Fatalf("attribute %q not found in schema", tt.name)
+			}
+			if attr.IsRequired() != tt.required {
+				t.Errorf("expected Required=%v, got %v", tt.required, attr.IsRequired())
+			}
+			if attr.IsOptional() != tt.optional {
+				t.Errorf("expected Optional=%v, got %v", tt.optional, attr.IsOptional())
+			}
+			if attr.IsComputed() != tt.computed {
+				t.Errorf("expected Computed=%v, got %v", tt.computed, attr.IsComputed())
+			}
+		})
+	}
+
+	if len(resp.Schema.Attributes) != 8 {
+		t.Errorf("expected 8 attributes, got %d", len(resp.Schema.Attributes))
+	}
+}
+
+func TestDefaultDeviceAssignmentResourceDoesNotImplementIdentity(t *testing.T) {
+	r := default_device_assignment.NewDefaultDeviceAssignmentResource()
+	_, ok := r.(tfresource.ResourceWithIdentity)
+	if ok {
+		t.Error("expected resource to NOT implement ResourceWithIdentity")
+	}
+}

--- a/internal/resources/device_management_service/resource_test.go
+++ b/internal/resources/device_management_service/resource_test.go
@@ -179,6 +179,26 @@ func TestResourceSchema(t *testing.T) {
 	if deviceIDsAttr.ElementType != types.StringType {
 		t.Errorf("expected device_ids ElementType to be StringType, got %T", deviceIDsAttr.ElementType)
 	}
+
+	serverCertAttr, ok := resp.Schema.Attributes["server_certificate"].(resourceschema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("server_certificate is not a SingleNestedAttribute")
+	}
+	if !serverCertAttr.IsOptional() {
+		t.Error("expected server_certificate to be Optional")
+	}
+	for _, name := range []string{"name", "data"} {
+		if _, ok := serverCertAttr.Attributes[name]; !ok {
+			t.Errorf("nested attribute %q not found in server_certificate", name)
+		}
+	}
+	dataAttr, ok := serverCertAttr.Attributes["data"].(resourceschema.StringAttribute)
+	if !ok {
+		t.Fatal("server_certificate.data is not a StringAttribute")
+	}
+	if !dataAttr.Sensitive {
+		t.Error("expected server_certificate.data to be Sensitive")
+	}
 }
 
 func TestResourceIdentitySchema(t *testing.T) {

--- a/internal/resources/organization_device/data_source.go
+++ b/internal/resources/organization_device/data_source.go
@@ -54,6 +54,8 @@ type OrganizationDeviceDataSourceModel struct {
 	WifiMacAddress          types.String   `tfsdk:"wifi_mac_address"`
 	BluetoothMacAddress     types.String   `tfsdk:"bluetooth_mac_address"`
 	EthernetMacAddress      []types.String `tfsdk:"ethernet_mac_address"`
+	ReleaserEntityType      types.String   `tfsdk:"releaser_entity_type"`
+	ReleaserID              types.String   `tfsdk:"releaser_id"`
 }
 
 func (d *OrganizationDeviceDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -160,6 +162,14 @@ func (d *OrganizationDeviceDataSource) Schema(ctx context.Context, req datasourc
 				Computed:    true,
 				Description: "The device's built-in Ethernet MAC addresses.",
 			},
+			"releaser_entity_type": schema.StringAttribute{
+				Computed:    true,
+				Description: "The type of entity that released the device from the organization.",
+			},
+			"releaser_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the entity that released the device from the organization.",
+			},
 		},
 	}
 }
@@ -223,6 +233,8 @@ func (d *OrganizationDeviceDataSource) Read(ctx context.Context, req datasource.
 	data.EthernetMacAddress = common.StringsToTypesStrings(device.Attributes.EthernetMacAddress)
 	data.IMEI = common.StringsToTypesStrings(device.Attributes.IMEI)
 	data.MEID = common.StringsToTypesStrings(device.Attributes.MEID)
+	data.ReleaserEntityType = types.StringPointerValue(common.StringPointerOrNil(device.Attributes.ReleaserEntityType))
+	data.ReleaserID = types.StringPointerValue(common.StringPointerOrNil(device.Attributes.ReleaserID))
 
 	tflog.Debug(ctx, "Read organization device", map[string]any{
 		"device_id":     data.ID.ValueString(),

--- a/internal/resources/organization_devices/data_source.go
+++ b/internal/resources/organization_devices/data_source.go
@@ -61,6 +61,8 @@ type OrganizationDeviceModel struct {
 	WifiMacAddress      types.String   `tfsdk:"wifi_mac_address"`
 	BluetoothMacAddress types.String   `tfsdk:"bluetooth_mac_address"`
 	EthernetMacAddress  []types.String `tfsdk:"ethernet_mac_address"`
+	ReleaserEntityType  types.String   `tfsdk:"releaser_entity_type"`
+	ReleaserID          types.String   `tfsdk:"releaser_id"`
 }
 
 func (d *OrganizationDevicesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -176,6 +178,14 @@ func (d *OrganizationDevicesDataSource) Schema(ctx context.Context, req datasour
 							Computed:    true,
 							Description: "The device's built-in Ethernet MAC addresses.",
 						},
+						"releaser_entity_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "The type of entity that released the device from the organization.",
+						},
+						"releaser_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The ID of the entity that released the device from the organization.",
+						},
 					},
 				},
 			},
@@ -243,6 +253,8 @@ func (d *OrganizationDevicesDataSource) Read(ctx context.Context, req datasource
 			EthernetMacAddress:  common.StringsToTypesStrings(device.Attributes.EthernetMacAddress),
 			IMEI:                common.StringsToTypesStrings(device.Attributes.IMEI),
 			MEID:                common.StringsToTypesStrings(device.Attributes.MEID),
+			ReleaserEntityType:  types.StringPointerValue(common.StringPointerOrNil(device.Attributes.ReleaserEntityType)),
+			ReleaserID:          types.StringPointerValue(common.StringPointerOrNil(device.Attributes.ReleaserID)),
 		}
 
 		data.Devices = append(data.Devices, deviceModel)

--- a/internal/resources/organization_devices/data_source_test.go
+++ b/internal/resources/organization_devices/data_source_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
@@ -73,14 +74,38 @@ func TestOrganizationDevicesDataSourceSchema(t *testing.T) {
 	}
 
 	nestedAttrs := listNested.NestedObject.Attributes
-	expectedNested := []string{
+	allExpectedNested := []string{
 		"id", "type", "serial_number", "added_to_org_date_time",
-		"updated_date_time", "device_model", "product_family", "status",
-		"imei", "meid", "ethernet_mac_address",
+		"released_from_org_date_time", "updated_date_time", "device_model",
+		"product_family", "product_type", "device_capacity", "part_number",
+		"order_number", "color", "status", "order_date_time", "imei", "meid",
+		"eid", "purchase_source_id", "purchase_source_type", "wifi_mac_address",
+		"bluetooth_mac_address", "ethernet_mac_address",
+		"releaser_entity_type", "releaser_id",
 	}
-	for _, name := range expectedNested {
+	for _, name := range allExpectedNested {
 		if _, ok := nestedAttrs[name]; !ok {
 			t.Errorf("nested attribute %q not found in devices", name)
+		}
+	}
+
+	idAttr, ok = nestedAttrs["id"].(dsschema.StringAttribute)
+	if !ok {
+		t.Fatal("expected nested 'id' to be a StringAttribute")
+	}
+	if !idAttr.IsRequired() {
+		t.Error("expected nested 'id' to be Required")
+	}
+
+	listStringAttrs := []string{"imei", "meid", "ethernet_mac_address"}
+	for _, name := range listStringAttrs {
+		listAttr, ok := nestedAttrs[name].(dsschema.ListAttribute)
+		if !ok {
+			t.Errorf("expected %q to be a ListAttribute", name)
+			continue
+		}
+		if listAttr.ElementType != types.StringType {
+			t.Errorf("expected %q ElementType to be StringType", name)
 		}
 	}
 }

--- a/internal/resources/package/data_source.go
+++ b/internal/resources/package/data_source.go
@@ -66,11 +66,11 @@ func (d *PackageDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			},
 			"url": schema.StringAttribute{
 				Computed:    true,
-				Description: "The package URL.",
+				Description: "The HTTPS URL to download the package.",
 			},
 			"hash": schema.StringAttribute{
 				Computed:    true,
-				Description: "The package hash.",
+				Description: "The hex string hash of the package file.",
 			},
 			"bundle_ids": schema.ListAttribute{
 				ElementType: types.StringType,

--- a/internal/resources/packages/data_source.go
+++ b/internal/resources/packages/data_source.go
@@ -82,11 +82,11 @@ func (d *PackagesDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 						},
 						"url": schema.StringAttribute{
 							Computed:    true,
-							Description: "The package URL.",
+							Description: "The HTTPS URL to download the package.",
 						},
 						"hash": schema.StringAttribute{
 							Computed:    true,
-							Description: "The package hash.",
+							Description: "The hex string hash of the package file.",
 						},
 						"bundle_ids": schema.ListAttribute{
 							ElementType: types.StringType,

--- a/internal/resources/user/data_source.go
+++ b/internal/resources/user/data_source.go
@@ -95,19 +95,19 @@ func (d *UserDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			},
 			"status": schema.StringAttribute{
 				Computed:    true,
-				Description: "The user's status.",
+				Description: "The status of the user.",
 			},
 			"managed_apple_account": schema.StringAttribute{
 				Computed:    true,
-				Description: "The user's managed Apple account.",
+				Description: "The Apple Account of the user registered in the system.",
 			},
 			"is_external_user": schema.BoolAttribute{
 				Computed:    true,
-				Description: "Whether the user is external.",
+				Description: "Indicates if the user is an external user invited to the organization.",
 			},
 			"role_ou_list": schema.ListNestedAttribute{
 				Computed:    true,
-				Description: "Role and organizational unit mappings.",
+				Description: "A list of role-organizational unit mappings for the user.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"role_name": schema.StringAttribute{
@@ -127,35 +127,35 @@ func (d *UserDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			},
 			"employee_number": schema.StringAttribute{
 				Computed:    true,
-				Description: "The employee number.",
+				Description: "The employee number of the user.",
 			},
 			"cost_center": schema.StringAttribute{
 				Computed:    true,
-				Description: "The cost center.",
+				Description: "The cost center the user belongs to in the organization.",
 			},
 			"division": schema.StringAttribute{
 				Computed:    true,
-				Description: "The division.",
+				Description: "The division the user belongs to in the organization.",
 			},
 			"department": schema.StringAttribute{
 				Computed:    true,
-				Description: "The department.",
+				Description: "The department the user belongs to in the organization.",
 			},
 			"job_title": schema.StringAttribute{
 				Computed:    true,
-				Description: "The job title.",
+				Description: "The job title the user holds in the organization.",
 			},
 			"start_date_time": schema.StringAttribute{
 				Computed:    true,
-				Description: "The start date and time.",
+				Description: "The date and time when the user started as part of the organization.",
 			},
 			"created_date_time": schema.StringAttribute{
 				Computed:    true,
-				Description: "The created date and time.",
+				Description: "The date and time that the user was created.",
 			},
 			"updated_date_time": schema.StringAttribute{
 				Computed:    true,
-				Description: "The updated date and time.",
+				Description: "The date and time that the user was last updated.",
 			},
 			"phone_numbers": schema.ListNestedAttribute{
 				Computed:    true,

--- a/internal/resources/user/data_source_test.go
+++ b/internal/resources/user/data_source_test.go
@@ -40,14 +40,67 @@ func TestUserDataSourceSchema(t *testing.T) {
 		t.Error("expected 'id' to be Required")
 	}
 
+	computedAttrs := []string{
+		"type", "first_name", "last_name", "middle_name", "status",
+		"managed_apple_account", "email", "employee_number", "cost_center",
+		"division", "department", "job_title", "start_date_time",
+		"created_date_time", "updated_date_time",
+	}
+	for _, name := range computedAttrs {
+		attr, ok := resp.Schema.Attributes[name]
+		if !ok {
+			t.Errorf("attribute %q not found", name)
+			continue
+		}
+		if !attr.IsComputed() {
+			t.Errorf("expected attribute %q to be Computed", name)
+		}
+	}
+
+	isExternalUserAttr, ok := resp.Schema.Attributes["is_external_user"]
+	if !ok {
+		t.Fatal("attribute 'is_external_user' not found")
+	}
+	if !isExternalUserAttr.IsComputed() {
+		t.Error("expected 'is_external_user' to be Computed")
+	}
+	if _, ok := isExternalUserAttr.(dsschema.BoolAttribute); !ok {
+		t.Error("expected 'is_external_user' to be a BoolAttribute")
+	}
+
 	listAttrs := []string{"role_ou_list", "phone_numbers"}
 	for _, name := range listAttrs {
 		attr, ok := resp.Schema.Attributes[name]
 		if !ok {
 			t.Fatalf("attribute %q not found", name)
 		}
-		if _, ok := attr.(dsschema.ListNestedAttribute); !ok {
+		listNested, ok := attr.(dsschema.ListNestedAttribute)
+		if !ok {
 			t.Errorf("expected attribute %q to be a ListNestedAttribute", name)
+			continue
+		}
+		if !listNested.IsComputed() {
+			t.Errorf("expected attribute %q to be Computed", name)
+		}
+	}
+
+	roleAttr, ok := resp.Schema.Attributes["role_ou_list"].(dsschema.ListNestedAttribute)
+	if !ok {
+		t.Fatal("expected 'role_ou_list' to be a ListNestedAttribute")
+	}
+	for _, name := range []string{"role_name", "ou_id"} {
+		if _, ok := roleAttr.NestedObject.Attributes[name]; !ok {
+			t.Errorf("nested attribute %q not found in role_ou_list", name)
+		}
+	}
+
+	phoneAttr, ok := resp.Schema.Attributes["phone_numbers"].(dsschema.ListNestedAttribute)
+	if !ok {
+		t.Fatal("expected 'phone_numbers' to be a ListNestedAttribute")
+	}
+	for _, name := range []string{"phone_number", "type"} {
+		if _, ok := phoneAttr.NestedObject.Attributes[name]; !ok {
+			t.Errorf("nested attribute %q not found in phone_numbers", name)
 		}
 	}
 }

--- a/internal/resources/user_group/data_source.go
+++ b/internal/resources/user_group/data_source.go
@@ -62,31 +62,31 @@ func (d *UserGroupDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			},
 			"ou_id": schema.StringAttribute{
 				Computed:    true,
-				Description: "The organizational unit ID.",
+				Description: "The identifier of the organizational unit the group belongs to.",
 			},
 			"name": schema.StringAttribute{
 				Computed:    true,
-				Description: "The user group name.",
+				Description: "The name of the user group.",
 			},
 			"group_type": schema.StringAttribute{
 				Computed:    true,
-				Description: "The user group type.",
+				Description: "The type of group.",
 			},
 			"total_member_count": schema.Int64Attribute{
 				Computed:    true,
-				Description: "The total member count.",
+				Description: "The total number of members in the group.",
 			},
 			"status": schema.StringAttribute{
 				Computed:    true,
-				Description: "The user group status.",
+				Description: "The status of the group.",
 			},
 			"created_date_time": schema.StringAttribute{
 				Computed:    true,
-				Description: "The created date and time.",
+				Description: "The date and time the user group was created.",
 			},
 			"updated_date_time": schema.StringAttribute{
 				Computed:    true,
-				Description: "The updated date and time.",
+				Description: "The date and time the user group was last modified.",
 			},
 			"user_ids": schema.ListAttribute{
 				ElementType: types.StringType,

--- a/internal/resources/user_groups/data_source.go
+++ b/internal/resources/user_groups/data_source.go
@@ -77,31 +77,31 @@ func (d *UserGroupsDataSource) Schema(ctx context.Context, req datasource.Schema
 						},
 						"ou_id": schema.StringAttribute{
 							Computed:    true,
-							Description: "The organizational unit ID.",
+							Description: "The identifier of the organizational unit the group belongs to.",
 						},
 						"name": schema.StringAttribute{
 							Computed:    true,
-							Description: "The user group name.",
+							Description: "The name of the user group.",
 						},
 						"group_type": schema.StringAttribute{
 							Computed:    true,
-							Description: "The user group type.",
+							Description: "The type of group.",
 						},
 						"total_member_count": schema.Int64Attribute{
 							Computed:    true,
-							Description: "The total member count.",
+							Description: "The total number of members in the group.",
 						},
 						"status": schema.StringAttribute{
 							Computed:    true,
-							Description: "The user group status.",
+							Description: "The status of the group.",
 						},
 						"created_date_time": schema.StringAttribute{
 							Computed:    true,
-							Description: "The created date and time.",
+							Description: "The date and time the user group was created.",
 						},
 						"updated_date_time": schema.StringAttribute{
 							Computed:    true,
-							Description: "The updated date and time.",
+							Description: "The date and time the user group was last modified.",
 						},
 					},
 				},

--- a/internal/resources/users/data_source.go
+++ b/internal/resources/users/data_source.go
@@ -111,19 +111,19 @@ func (d *UsersDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 						},
 						"status": schema.StringAttribute{
 							Computed:    true,
-							Description: "The user's status.",
+							Description: "The status of the user.",
 						},
 						"managed_apple_account": schema.StringAttribute{
 							Computed:    true,
-							Description: "The user's managed Apple account.",
+							Description: "The Apple Account of the user registered in the system.",
 						},
 						"is_external_user": schema.BoolAttribute{
 							Computed:    true,
-							Description: "Whether the user is external.",
+							Description: "Indicates if the user is an external user invited to the organization.",
 						},
 						"role_ou_list": schema.ListNestedAttribute{
 							Computed:    true,
-							Description: "Role and organizational unit mappings.",
+							Description: "A list of role-organizational unit mappings for the user.",
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"role_name": schema.StringAttribute{
@@ -143,35 +143,35 @@ func (d *UsersDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 						},
 						"employee_number": schema.StringAttribute{
 							Computed:    true,
-							Description: "The employee number.",
+							Description: "The employee number of the user.",
 						},
 						"cost_center": schema.StringAttribute{
 							Computed:    true,
-							Description: "The cost center.",
+							Description: "The cost center the user belongs to in the organization.",
 						},
 						"division": schema.StringAttribute{
 							Computed:    true,
-							Description: "The division.",
+							Description: "The division the user belongs to in the organization.",
 						},
 						"department": schema.StringAttribute{
 							Computed:    true,
-							Description: "The department.",
+							Description: "The department the user belongs to in the organization.",
 						},
 						"job_title": schema.StringAttribute{
 							Computed:    true,
-							Description: "The job title.",
+							Description: "The job title the user holds in the organization.",
 						},
 						"start_date_time": schema.StringAttribute{
 							Computed:    true,
-							Description: "The start date and time.",
+							Description: "The date and time when the user started as part of the organization.",
 						},
 						"created_date_time": schema.StringAttribute{
 							Computed:    true,
-							Description: "The created date and time.",
+							Description: "The date and time that the user was created.",
 						},
 						"updated_date_time": schema.StringAttribute{
 							Computed:    true,
-							Description: "The updated date and time.",
+							Description: "The date and time that the user was last updated.",
 						},
 						"phone_numbers": schema.ListNestedAttribute{
 							Computed:    true,

--- a/internal/resources/users/helpers_test.go
+++ b/internal/resources/users/helpers_test.go
@@ -1,0 +1,166 @@
+// Copyright Neil Martin 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package users
+
+import (
+	"testing"
+
+	"github.com/neilmartin83/terraform-provider-axm/internal/client"
+)
+
+func TestFlattenUser(t *testing.T) {
+	user := client.User{
+		Type: "users",
+		ID:   "user-1",
+		Attributes: client.UserAttributes{
+			FirstName:           "Jane",
+			LastName:            "Doe",
+			MiddleName:          "M",
+			Status:              "ACTIVE",
+			ManagedAppleAccount: "jane.doe@example.com",
+			IsExternalUser:      false,
+			RoleOuList: []client.UserRoleOuMapping{
+				{RoleName: "Teacher", OuID: "ou-1"},
+			},
+			Email:           "jane@example.com",
+			EmployeeNumber:  "12345",
+			CostCenter:      "CC-1",
+			Division:        "Div-1",
+			Department:      "Dept-1",
+			JobTitle:        "Teacher",
+			StartDateTime:   "2024-01-01T00:00:00Z",
+			CreatedDateTime: "2024-01-01T00:00:00Z",
+			UpdatedDateTime: "2024-06-01T00:00:00Z",
+			PhoneNumbers: []client.UserPhoneNumber{
+				{PhoneNumber: "555-0100", Type: "WORK"},
+			},
+		},
+	}
+
+	model := flattenUser(user)
+
+	if model.ID.ValueString() != "user-1" {
+		t.Errorf("expected ID user-1, got %s", model.ID.ValueString())
+	}
+	if model.Type.ValueString() != "users" {
+		t.Errorf("expected Type users, got %s", model.Type.ValueString())
+	}
+	if model.FirstName.ValueString() != "Jane" {
+		t.Errorf("expected FirstName Jane, got %s", model.FirstName.ValueString())
+	}
+	if model.LastName.ValueString() != "Doe" {
+		t.Errorf("expected LastName Doe, got %s", model.LastName.ValueString())
+	}
+	if !model.MiddleName.IsNull() && model.MiddleName.ValueString() != "M" {
+		t.Errorf("expected MiddleName M, got %s", model.MiddleName.ValueString())
+	}
+	if model.Status.ValueString() != "ACTIVE" {
+		t.Errorf("expected Status ACTIVE, got %s", model.Status.ValueString())
+	}
+	if model.ManagedAppleAccount.ValueString() != "jane.doe@example.com" {
+		t.Errorf("expected ManagedAppleAccount jane.doe@example.com, got %s", model.ManagedAppleAccount.ValueString())
+	}
+	if model.IsExternalUser.ValueBool() != false {
+		t.Error("expected IsExternalUser false")
+	}
+	if model.Email.ValueString() != "jane@example.com" {
+		t.Errorf("expected Email jane@example.com, got %s", model.Email.ValueString())
+	}
+	if model.EmployeeNumber.ValueString() != "12345" {
+		t.Errorf("expected EmployeeNumber 12345, got %s", model.EmployeeNumber.ValueString())
+	}
+	if model.CostCenter.ValueString() != "CC-1" {
+		t.Errorf("expected CostCenter CC-1, got %s", model.CostCenter.ValueString())
+	}
+	if model.Division.ValueString() != "Div-1" {
+		t.Errorf("expected Division Div-1, got %s", model.Division.ValueString())
+	}
+	if model.Department.ValueString() != "Dept-1" {
+		t.Errorf("expected Department Dept-1, got %s", model.Department.ValueString())
+	}
+	if model.JobTitle.ValueString() != "Teacher" {
+		t.Errorf("expected JobTitle Teacher, got %s", model.JobTitle.ValueString())
+	}
+	if model.StartDateTime.ValueString() != "2024-01-01T00:00:00Z" {
+		t.Errorf("expected StartDateTime 2024-01-01T00:00:00Z, got %s", model.StartDateTime.ValueString())
+	}
+	if model.CreatedDateTime.ValueString() != "2024-01-01T00:00:00Z" {
+		t.Errorf("expected CreatedDateTime 2024-01-01T00:00:00Z, got %s", model.CreatedDateTime.ValueString())
+	}
+	if model.UpdatedDateTime.ValueString() != "2024-06-01T00:00:00Z" {
+		t.Errorf("expected UpdatedDateTime 2024-06-01T00:00:00Z, got %s", model.UpdatedDateTime.ValueString())
+	}
+
+	if len(model.RoleOuList) != 1 {
+		t.Fatalf("expected 1 role_ou_list entry, got %d", len(model.RoleOuList))
+	}
+	if model.RoleOuList[0].RoleName.ValueString() != "Teacher" {
+		t.Errorf("expected role name Teacher, got %s", model.RoleOuList[0].RoleName.ValueString())
+	}
+	if model.RoleOuList[0].OuID.ValueString() != "ou-1" {
+		t.Errorf("expected ou ID ou-1, got %s", model.RoleOuList[0].OuID.ValueString())
+	}
+
+	if len(model.PhoneNumbers) != 1 {
+		t.Fatalf("expected 1 phone number, got %d", len(model.PhoneNumbers))
+	}
+	if model.PhoneNumbers[0].PhoneNumber.ValueString() != "555-0100" {
+		t.Errorf("expected phone 555-0100, got %s", model.PhoneNumbers[0].PhoneNumber.ValueString())
+	}
+	if model.PhoneNumbers[0].Type.ValueString() != "WORK" {
+		t.Errorf("expected phone type WORK, got %s", model.PhoneNumbers[0].Type.ValueString())
+	}
+}
+
+func TestFlattenUser_EmptyOptionalFields(t *testing.T) {
+	user := client.User{
+		Type: "users",
+		ID:   "user-2",
+		Attributes: client.UserAttributes{
+			FirstName:           "John",
+			LastName:            "Smith",
+			Status:              "ACTIVE",
+			ManagedAppleAccount: "john.smith@example.com",
+		},
+	}
+
+	model := flattenUser(user)
+
+	if !model.MiddleName.IsNull() {
+		t.Error("expected MiddleName to be null when empty")
+	}
+	if !model.Email.IsNull() {
+		t.Error("expected Email to be null when empty")
+	}
+	if !model.EmployeeNumber.IsNull() {
+		t.Error("expected EmployeeNumber to be null when empty")
+	}
+	if !model.CostCenter.IsNull() {
+		t.Error("expected CostCenter to be null when empty")
+	}
+	if !model.Division.IsNull() {
+		t.Error("expected Division to be null when empty")
+	}
+	if !model.Department.IsNull() {
+		t.Error("expected Department to be null when empty")
+	}
+	if !model.JobTitle.IsNull() {
+		t.Error("expected JobTitle to be null when empty")
+	}
+	if !model.StartDateTime.IsNull() {
+		t.Error("expected StartDateTime to be null when empty")
+	}
+	if !model.CreatedDateTime.IsNull() {
+		t.Error("expected CreatedDateTime to be null when empty")
+	}
+	if !model.UpdatedDateTime.IsNull() {
+		t.Error("expected UpdatedDateTime to be null when empty")
+	}
+	if len(model.RoleOuList) != 0 {
+		t.Errorf("expected 0 role_ou_list entries, got %d", len(model.RoleOuList))
+	}
+	if len(model.PhoneNumbers) != 0 {
+		t.Errorf("expected 0 phone numbers, got %d", len(model.PhoneNumbers))
+	}
+}


### PR DESCRIPTION
## Summary

### New fields
- **organization_device** / **organization_devices** data sources: added `releaser_entity_type` and `releaser_id` computed attributes matching the Apple API response.

### Schema description alignment
Aligned all schema descriptions across User, Users, UserGroup, UserGroups, App, Apps, Package, Packages, Blueprint, Blueprints, Configuration (data source + resource), organization devices, and audit_events data sources with the Apple API spec.

### Unit test gap fill
- **default_device_assignment** — new resource: metadata, schema, identity check + helper function tests (familyServerMap, uniqueServerIDs, reconcileFamily)
- **blueprint** — helpers: buildRelationshipData, diffIDs
- **users** — flattenUser
- **audit_events** — flattenAuditEvent, full nested attribute schema check (15 of 15)
- **user** — full computed attribute schema check (16 of 16)
- **organization_devices** — full nested attribute schema check (25 of 25)
- **blueprints** — full nested attribute schema check (7 of 7)
- **device_management_service** — server_certificate schema check